### PR TITLE
feat: 보일러 리스트 필터링 조회 기능 추가

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2025-04-16T01:42:01.204524300Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\SSAFY\.android\avd\Pixel_6_Pro_API_34.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-04-16T01:42:01.204524300Z">
+        <DropdownSelection timestamp="2025-04-17T00:01:38.987239500Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\SSAFY\.android\avd\Pixel_6_Pro_API_34.avd" />

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,6 +4,7 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.intellij.execution.junit.AbstractAllInDirectoryConfigurationProducer" />
+        <option value="com.intellij.execution.junit.AllInPackageConfigurationProducer" />
+        <option value="com.intellij.execution.junit.PatternConfigurationProducer" />
+        <option value="com.intellij.execution.junit.TestInClassConfigurationProducer" />
+        <option value="com.intellij.execution.junit.UniqueIdConfigurationProducer" />
+        <option value="com.intellij.execution.junit.testDiscovery.JUnitTestDiscoveryConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinJUnitRunConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinPatternConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        
     </application>
 
 </manifest>

--- a/app/src/main/java/com/ssafy/ttasoom/MainActivity.kt
+++ b/app/src/main/java/com/ssafy/ttasoom/MainActivity.kt
@@ -4,11 +4,12 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.ssafy.feature.auth.ui.LoginActivity
+import com.ssafy.feature.boiler.ui.BoilerTestActivity
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        startActivity(Intent(this, LoginActivity::class.java))
+        startActivity(Intent(this, BoilerTestActivity::class.java))
         finish()
     }
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,5 +1,4 @@
 
-
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.kotlin.android)
@@ -7,10 +6,8 @@ plugins {
     kotlin("kapt")
 }
 
-
-
 android {
-    namespace = "com.ssafy.domain"
+    namespace = "com.ssafy.data"
     compileSdk = 34
 
     defaultConfig {
@@ -40,8 +37,21 @@ android {
 
 
 }
-dependencies{
+dependencies {
     implementation(project(":domain"))
+
+    // ✅ Retrofit 직접 명시
+    implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation("com.squareup.retrofit2:converter-gson:2.9.0")
+    implementation("com.squareup.okhttp3:logging-interceptor:4.11.0")
+
+    // ✅ Hilt
     implementation("com.google.dagger:hilt-android:2.48")
     kapt("com.google.dagger:hilt-compiler:2.48")
+
+    // ✅ 테스트
+    testImplementation(libs.junit)
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.espresso.core)
 }
+

--- a/data/src/main/java/com/ssafy/data/boiler/mapper/BoilerMapper.kt
+++ b/data/src/main/java/com/ssafy/data/boiler/mapper/BoilerMapper.kt
@@ -1,0 +1,16 @@
+package com.ssafy.data.boiler.mapper
+
+import com.ssafy.data.boiler.model.BoilerItemDto
+import com.ssafy.domain.boiler.model.Boiler
+
+fun BoilerItemDto.toDomain(): Boiler {
+    return Boiler(
+        companyName = enterprise ?: "",
+        certificationType = certificationType ?: "",
+        circulationType = circulationType ?: "",
+        fuelType = fuelType ?: "",
+        productName = productName ?: "",
+        certificationStartDate = certificationDate ?: "",
+        imageUrl = "" // 직접 가공하는 값
+    )
+}

--- a/data/src/main/java/com/ssafy/data/boiler/model/BoilerItemDto.kt
+++ b/data/src/main/java/com/ssafy/data/boiler/model/BoilerItemDto.kt
@@ -1,0 +1,23 @@
+package com.ssafy.data.boiler.model
+
+import com.google.gson.annotations.SerializedName
+
+data class BoilerItemDto(
+    @SerializedName("기업명")
+    val enterprise: String?, // 기업명
+
+    @SerializedName("인증종류")
+    val certificationType: String?, // 인증 종류
+
+    @SerializedName("순환방식")
+    val circulationType: String?, // 순환 방식
+
+    @SerializedName("사용연료")
+    val fuelType: String?, // 사용 연료
+
+    @SerializedName("상표명")
+    val productName: String?, // 제품명
+
+    @SerializedName("인증일")
+    val certificationDate: String? // 인증 시작일
+)

--- a/data/src/main/java/com/ssafy/data/boiler/model/BoilerResponseDto.kt
+++ b/data/src/main/java/com/ssafy/data/boiler/model/BoilerResponseDto.kt
@@ -1,0 +1,8 @@
+package com.ssafy.data.boiler.model
+
+import com.google.gson.annotations.SerializedName
+
+data class BoilerResponseDto(
+    @SerializedName("data")
+    val data: List<BoilerItemDto>
+)

--- a/data/src/main/java/com/ssafy/data/boiler/provider/BoilerApiService.kt
+++ b/data/src/main/java/com/ssafy/data/boiler/provider/BoilerApiService.kt
@@ -2,8 +2,14 @@ package com.ssafy.data.boiler.provider
 
 import com.ssafy.data.boiler.model.BoilerResponseDto
 import retrofit2.http.GET
+import retrofit2.http.Query
 
 interface BoilerApiService {
-    @GET("/boilers") // 실제 서버 경로에 맞춰서 수정
-    suspend fun getBoilerList(): BoilerResponseDto
+    @GET("/boilers")
+    suspend fun getBoilerList(
+        @Query("companyName") companyName: String? = null,
+        @Query("certificationType") certificationType: String? = null,
+        @Query("circulationType") circulationType: String? = null,
+        @Query("fuelType") fuelType: String? = null
+    ): BoilerResponseDto
 }

--- a/data/src/main/java/com/ssafy/data/boiler/provider/BoilerApiService.kt
+++ b/data/src/main/java/com/ssafy/data/boiler/provider/BoilerApiService.kt
@@ -1,0 +1,9 @@
+package com.ssafy.data.boiler.provider
+
+import com.ssafy.data.boiler.model.BoilerResponseDto
+import retrofit2.http.GET
+
+interface BoilerApiService {
+    @GET("/boilers") // 실제 서버 경로에 맞춰서 수정
+    suspend fun getBoilerList(): BoilerResponseDto
+}

--- a/data/src/main/java/com/ssafy/data/boiler/provider/BoilerRemoteDataSource.kt
+++ b/data/src/main/java/com/ssafy/data/boiler/provider/BoilerRemoteDataSource.kt
@@ -3,5 +3,10 @@ package com.ssafy.data.boiler.provider
 import com.ssafy.data.boiler.model.BoilerItemDto
 
 interface BoilerRemoteDataSource {
-    suspend fun getBoilerList(): Result<List<BoilerItemDto>>
+    suspend fun getBoilerList(
+        companyName: String? = null,
+        certificationType: String? = null,
+        circulationType: String? = null,
+        fuelType: String? = null
+    ): Result<List<BoilerItemDto>>
 }

--- a/data/src/main/java/com/ssafy/data/boiler/provider/BoilerRemoteDataSource.kt
+++ b/data/src/main/java/com/ssafy/data/boiler/provider/BoilerRemoteDataSource.kt
@@ -1,0 +1,7 @@
+package com.ssafy.data.boiler.provider
+
+import com.ssafy.data.boiler.model.BoilerItemDto
+
+interface BoilerRemoteDataSource {
+    suspend fun getBoilerList(): Result<List<BoilerItemDto>>
+}

--- a/data/src/main/java/com/ssafy/data/boiler/provider/BoilerRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/ssafy/data/boiler/provider/BoilerRemoteDataSourceImpl.kt
@@ -1,17 +1,27 @@
 package com.ssafy.data.boiler.provider
 
 import com.ssafy.data.boiler.model.BoilerItemDto
-import com.ssafy.data.boiler.provider.BoilerRemoteDataSource
 
 class BoilerRemoteDataSourceImpl(
     private val api: BoilerApiService
 ) : BoilerRemoteDataSource {
-    override suspend fun getBoilerList(): Result<List<BoilerItemDto>> {
+
+    override suspend fun getBoilerList(
+        companyName: String?,
+        certificationType: String?,
+        circulationType: String?,
+        fuelType: String?
+    ): Result<List<BoilerItemDto>> {
         return try {
-            val response = api.getBoilerList()
+            val response = api.getBoilerList(
+                companyName, certificationType, circulationType, fuelType
+            )
             Result.success(response.data)
         } catch (e: Exception) {
             Result.failure(e)
         }
     }
 }
+
+
+

--- a/data/src/main/java/com/ssafy/data/boiler/provider/BoilerRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/ssafy/data/boiler/provider/BoilerRemoteDataSourceImpl.kt
@@ -1,0 +1,17 @@
+package com.ssafy.data.boiler.provider
+
+import com.ssafy.data.boiler.model.BoilerItemDto
+import com.ssafy.data.boiler.provider.BoilerRemoteDataSource
+
+class BoilerRemoteDataSourceImpl(
+    private val api: BoilerApiService
+) : BoilerRemoteDataSource {
+    override suspend fun getBoilerList(): Result<List<BoilerItemDto>> {
+        return try {
+            val response = api.getBoilerList()
+            Result.success(response.data)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}

--- a/data/src/main/java/com/ssafy/data/boiler/provider/FakeBoilerRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/ssafy/data/boiler/provider/FakeBoilerRemoteDataSourceImpl.kt
@@ -1,0 +1,30 @@
+package com.ssafy.data.boiler.provider
+
+import com.ssafy.data.boiler.model.BoilerItemDto
+import kotlinx.coroutines.delay
+
+class FakeBoilerRemoteDataSourceImpl : BoilerRemoteDataSource {
+    override suspend fun getBoilerList(): Result<List<BoilerItemDto>> {
+        delay(1000)
+        return Result.success(
+            listOf(
+                BoilerItemDto(
+                    enterprise = "SSAFY Boiler Inc.",
+                    certificationType = "1종",
+                    circulationType = "자연순환",
+                    fuelType = "도시가스",
+                    productName = "SmartBoiler X100",
+                    certificationDate = "2023-10-01"
+                ),
+                BoilerItemDto(
+                    enterprise = "WarmTech",
+                    certificationType = "2종",
+                    circulationType = "강제순환",
+                    fuelType = "등유",
+                    productName = "HeatMaster 2000",
+                    certificationDate = "2022-05-15"
+                )
+            )
+        )
+    }
+}

--- a/data/src/main/java/com/ssafy/data/boiler/provider/FakeBoilerRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/ssafy/data/boiler/provider/FakeBoilerRemoteDataSourceImpl.kt
@@ -4,27 +4,41 @@ import com.ssafy.data.boiler.model.BoilerItemDto
 import kotlinx.coroutines.delay
 
 class FakeBoilerRemoteDataSourceImpl : BoilerRemoteDataSource {
-    override suspend fun getBoilerList(): Result<List<BoilerItemDto>> {
-        delay(1000)
-        return Result.success(
-            listOf(
-                BoilerItemDto(
-                    enterprise = "SSAFY Boiler Inc.",
-                    certificationType = "1종",
-                    circulationType = "자연순환",
-                    fuelType = "도시가스",
-                    productName = "SmartBoiler X100",
-                    certificationDate = "2023-10-01"
-                ),
-                BoilerItemDto(
-                    enterprise = "WarmTech",
-                    certificationType = "2종",
-                    circulationType = "강제순환",
-                    fuelType = "등유",
-                    productName = "HeatMaster 2000",
-                    certificationDate = "2022-05-15"
-                )
-            )
+
+    private val dummyData = listOf(
+        BoilerItemDto(
+            enterprise = "SSAFY Boiler Inc.",
+            certificationType = "1종",
+            circulationType = "자연순환",
+            fuelType = "도시가스",
+            productName = "SmartBoiler X100",
+            certificationDate = "2023-10-01"
+        ),
+        BoilerItemDto(
+            enterprise = "WarmTech",
+            certificationType = "2종",
+            circulationType = "강제순환",
+            fuelType = "등유",
+            productName = "HeatMaster 2000",
+            certificationDate = "2022-05-15"
         )
+    )
+
+    override suspend fun getBoilerList(
+        companyName: String?,
+        certificationType: String?,
+        circulationType: String?,
+        fuelType: String?
+    ): Result<List<BoilerItemDto>> {
+        delay(1000)
+
+        val filtered = dummyData.filter { item ->
+            (companyName == null || item.enterprise == companyName) &&
+                    (certificationType == null || item.certificationType == certificationType) &&
+                    (circulationType == null || item.circulationType == circulationType) &&
+                    (fuelType == null || item.fuelType == fuelType)
+        }
+
+        return Result.success(filtered)
     }
 }

--- a/data/src/main/java/com/ssafy/data/boiler/repository/BoilerRepositoryImpl.kt
+++ b/data/src/main/java/com/ssafy/data/boiler/repository/BoilerRepositoryImpl.kt
@@ -1,0 +1,14 @@
+import com.ssafy.data.boiler.mapper.toDomain
+import com.ssafy.data.boiler.provider.BoilerRemoteDataSource
+import com.ssafy.domain.boiler.model.Boiler
+import com.ssafy.domain.boiler.repository.BoilerRepository
+
+class BoilerRepositoryImpl(
+    private val remote: BoilerRemoteDataSource
+) : BoilerRepository {
+    override suspend fun getBoilerList(): Result<List<Boiler>> {
+        return remote.getBoilerList().map { list ->
+            list.map { it.toDomain() }
+        }
+    }
+}

--- a/data/src/main/java/com/ssafy/data/boiler/repository/BoilerRepositoryImpl.kt
+++ b/data/src/main/java/com/ssafy/data/boiler/repository/BoilerRepositoryImpl.kt
@@ -1,3 +1,5 @@
+package com.ssafy.data.boiler.repository
+
 import com.ssafy.data.boiler.mapper.toDomain
 import com.ssafy.data.boiler.provider.BoilerRemoteDataSource
 import com.ssafy.domain.boiler.model.Boiler
@@ -6,8 +8,25 @@ import com.ssafy.domain.boiler.repository.BoilerRepository
 class BoilerRepositoryImpl(
     private val remote: BoilerRemoteDataSource
 ) : BoilerRepository {
+
     override suspend fun getBoilerList(): Result<List<Boiler>> {
         return remote.getBoilerList().map { list ->
+            list.map { it.toDomain() }
+        }
+    }
+
+    override suspend fun getFilterBoilerList(
+        companyName: String?,
+        certificationType: String?,
+        circulationType: String?,
+        fuelType: String?
+    ): Result<List<Boiler>> {
+        return remote.getBoilerList(
+            companyName = companyName,
+            certificationType = certificationType,
+            circulationType = circulationType,
+            fuelType = fuelType
+        ).map { list ->
             list.map { it.toDomain() }
         }
     }

--- a/di/build.gradle.kts
+++ b/di/build.gradle.kts
@@ -50,4 +50,10 @@ dependencies {
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+
+    implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation("com.squareup.retrofit2:converter-gson:2.9.0")
+
+    implementation("com.google.dagger:hilt-android:2.48")
+    kapt("com.google.dagger:hilt-compiler:2.48")
 }

--- a/di/src/main/java/com/ssafy/di/BoilerModule.kt
+++ b/di/src/main/java/com/ssafy/di/BoilerModule.kt
@@ -1,0 +1,32 @@
+package com.ssafy.di
+
+import BoilerRepositoryImpl
+import com.ssafy.data.boiler.provider.BoilerRemoteDataSource
+import com.ssafy.data.boiler.provider.FakeBoilerRemoteDataSourceImpl // 이거 꼭 추가!
+import com.ssafy.domain.boiler.repository.BoilerRepository
+import com.ssafy.domain.boiler.usecase.GetBoilerListUseCase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+
+@Module
+@InstallIn(SingletonComponent::class)
+object BoilerModule {
+
+    @Provides
+    fun provideBoilerRemoteDataSource(): BoilerRemoteDataSource {
+        return FakeBoilerRemoteDataSourceImpl()
+    }
+
+    @Provides
+    fun provideBoilerRepository(remote: BoilerRemoteDataSource): BoilerRepository {
+        return BoilerRepositoryImpl(remote)
+    }
+
+    @Provides
+    fun provideGetBoilerListUseCase(repo: BoilerRepository): GetBoilerListUseCase {
+        return GetBoilerListUseCase(repo)
+    }
+}

--- a/di/src/main/java/com/ssafy/di/BoilerModule.kt
+++ b/di/src/main/java/com/ssafy/di/BoilerModule.kt
@@ -1,15 +1,15 @@
 package com.ssafy.di
 
-import BoilerRepositoryImpl
+import com.ssafy.data.boiler.repository.BoilerRepositoryImpl
 import com.ssafy.data.boiler.provider.BoilerRemoteDataSource
-import com.ssafy.data.boiler.provider.FakeBoilerRemoteDataSourceImpl // 이거 꼭 추가!
+import com.ssafy.data.boiler.provider.FakeBoilerRemoteDataSourceImpl
 import com.ssafy.domain.boiler.repository.BoilerRepository
 import com.ssafy.domain.boiler.usecase.GetBoilerListUseCase
+import com.ssafy.domain.boiler.usecase.GetFilterBoilerListUseCase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -28,5 +28,10 @@ object BoilerModule {
     @Provides
     fun provideGetBoilerListUseCase(repo: BoilerRepository): GetBoilerListUseCase {
         return GetBoilerListUseCase(repo)
+    }
+
+    @Provides
+    fun provideGetFilterBoilerListUseCase(repo: BoilerRepository): GetFilterBoilerListUseCase {
+        return GetFilterBoilerListUseCase(repo)
     }
 }

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -7,3 +7,12 @@ java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
 }
+
+kotlin {
+    jvmToolchain(17)
+}
+
+dependencies {
+    // 🔧 DI를 위한 javax.inject 의존성 추가
+    implementation("javax.inject:javax.inject:1")
+}

--- a/domain/src/main/java/com/ssafy/domain/boiler/model/Boiler.kt
+++ b/domain/src/main/java/com/ssafy/domain/boiler/model/Boiler.kt
@@ -1,0 +1,11 @@
+package com.ssafy.domain.boiler.model
+
+data class Boiler(
+    val companyName: String,
+    val certificationType: String, // 인증 종류
+    val circulationType: String, // 순환 바식
+    val fuelType: String, // 사용 연료
+    val productName: String, // 제품명
+    val certificationStartDate: String, // 인증 시작일
+    val imageUrl: String
+)

--- a/domain/src/main/java/com/ssafy/domain/boiler/repository/BoilerRepository.kt
+++ b/domain/src/main/java/com/ssafy/domain/boiler/repository/BoilerRepository.kt
@@ -1,0 +1,7 @@
+package com.ssafy.domain.boiler.repository
+
+import com.ssafy.domain.boiler.model.Boiler
+
+interface BoilerRepository {
+    suspend fun getBoilerList(): Result<List<Boiler>>
+}

--- a/domain/src/main/java/com/ssafy/domain/boiler/repository/BoilerRepository.kt
+++ b/domain/src/main/java/com/ssafy/domain/boiler/repository/BoilerRepository.kt
@@ -4,4 +4,10 @@ import com.ssafy.domain.boiler.model.Boiler
 
 interface BoilerRepository {
     suspend fun getBoilerList(): Result<List<Boiler>>
+    suspend fun getFilterBoilerList(
+        companyName: String?,
+        certificationType: String?, // 인증 종류
+        circulationType: String?, // 순환 바식
+        fuelType: String?, // 사용 연료
+    ) : Result<List<Boiler>>
 }

--- a/domain/src/main/java/com/ssafy/domain/boiler/usecase/GetBoilerListUseCase.kt
+++ b/domain/src/main/java/com/ssafy/domain/boiler/usecase/GetBoilerListUseCase.kt
@@ -1,0 +1,13 @@
+package com.ssafy.domain.boiler.usecase
+
+import com.ssafy.domain.boiler.model.Boiler
+import com.ssafy.domain.boiler.repository.BoilerRepository
+import javax.inject.Inject
+
+class GetBoilerListUseCase @Inject constructor(
+    private val repository: BoilerRepository
+) {
+    suspend operator fun invoke(): Result<List<Boiler>> {
+        return repository.getBoilerList()
+    }
+}

--- a/domain/src/main/java/com/ssafy/domain/boiler/usecase/GetFilterBoilerListUseCase.kt
+++ b/domain/src/main/java/com/ssafy/domain/boiler/usecase/GetFilterBoilerListUseCase.kt
@@ -1,0 +1,18 @@
+package com.ssafy.domain.boiler.usecase
+
+import com.ssafy.domain.boiler.model.Boiler
+import com.ssafy.domain.boiler.repository.BoilerRepository
+import javax.inject.Inject
+
+class GetFilterBoilerListUseCase @Inject constructor(
+    private val repository: BoilerRepository
+) {
+    suspend operator fun invoke(
+        companyName: String?,
+        certificationType: String?,
+        circulationType: String?,
+        fuelType: String?
+    ): Result<List<Boiler>> {
+        return repository.getFilterBoilerList(companyName, certificationType, circulationType, fuelType)
+    }
+}

--- a/feature/build.gradle.kts
+++ b/feature/build.gradle.kts
@@ -34,15 +34,19 @@ android {
         jvmTarget = "1.8"
     }
 
+    viewBinding {
+        enable = true
+    }
 
 }
 
 dependencies {
     implementation(project(":domain"))
-
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
+    implementation(libs.androidx.activity)
+    implementation(libs.androidx.constraintlayout)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/feature/src/main/AndroidManifest.xml
+++ b/feature/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.ssafy.feature">
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -7,10 +9,18 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Ttasoom">
+
         <activity
             android:name=".auth.ui.LoginActivity"
             android:exported="true">
-
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
         </activity>
+
+        <activity
+            android:name=".boiler.ui.BoilerTestActivity"
+            android:exported="true"/>
     </application>
 </manifest>

--- a/feature/src/main/java/com/ssafy/feature/boiler/ui/BoilerTestActivity.kt
+++ b/feature/src/main/java/com/ssafy/feature/boiler/ui/BoilerTestActivity.kt
@@ -38,5 +38,20 @@ class BoilerTestActivity : AppCompatActivity() {
         binding.button.setOnClickListener {
             viewModel.fetchBoilers()
         }
+
+        binding.filterButton.setOnClickListener {
+            val company = binding.etCompanyName.text.toString().ifBlank { null }
+            val cert = binding.etCertificationType.text.toString().ifBlank { null }
+            val circ = binding.etCirculationType.text.toString().ifBlank { null }
+            val fuel = binding.etFuelType.text.toString().ifBlank { null }
+
+            viewModel.fetchFilteredBoilers(
+                companyName = company,
+                certificationType = cert,
+                circulationType = circ,
+                fuelType = fuel
+            )
+        }
+
     }
 }

--- a/feature/src/main/java/com/ssafy/feature/boiler/ui/BoilerTestActivity.kt
+++ b/feature/src/main/java/com/ssafy/feature/boiler/ui/BoilerTestActivity.kt
@@ -1,0 +1,42 @@
+package com.ssafy.feature.boiler.ui
+
+import android.os.Bundle
+import android.util.Log
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import com.ssafy.feature.databinding.ActivityBoilerTestBinding
+import com.ssafy.feature.boiler.viewmodel.BoilerViewModel
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class BoilerTestActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityBoilerTestBinding
+    private val viewModel: BoilerViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityBoilerTestBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        viewModel.boilerListResult.observe(this) { result ->
+            result.fold(
+                onSuccess = { list ->
+                    Log.d("BoilerTest", "불러온 보일러 수: ${list.size}")
+                    list.forEach {
+                        Log.d("BoilerTest", "${it.companyName} / ${it.productName}")
+                    }
+                    binding.textView.text = "불러온 보일러 수: ${list.size}"
+                },
+                onFailure = { e ->
+                    Log.e("BoilerTest", "에러 발생: ${e.message}")
+                    binding.textView.text = "에러: ${e.message}"
+                }
+            )
+        }
+
+        binding.button.setOnClickListener {
+            viewModel.fetchBoilers()
+        }
+    }
+}

--- a/feature/src/main/java/com/ssafy/feature/boiler/viewmodel/BoilerViewModel.kt
+++ b/feature/src/main/java/com/ssafy/feature/boiler/viewmodel/BoilerViewModel.kt
@@ -6,13 +6,15 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ssafy.domain.boiler.model.Boiler
 import com.ssafy.domain.boiler.usecase.GetBoilerListUseCase
+import com.ssafy.domain.boiler.usecase.GetFilterBoilerListUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class BoilerViewModel @Inject constructor(
-    private val getBoilerListUseCase: GetBoilerListUseCase
+    private val getBoilerListUseCase: GetBoilerListUseCase,
+    private val getFilterBoilerListUseCase: GetFilterBoilerListUseCase
 ) : ViewModel() {
 
     private val _boilerListResult = MutableLiveData<Result<List<Boiler>>>()
@@ -24,4 +26,19 @@ class BoilerViewModel @Inject constructor(
             _boilerListResult.value = result
         }
     }
+
+    fun fetchFilteredBoilers(
+        companyName: String? = null,
+        certificationType: String? = null,
+        circulationType: String? = null,
+        fuelType: String? = null
+    ) {
+        viewModelScope.launch {
+            val result = getFilterBoilerListUseCase(
+                companyName, certificationType, circulationType, fuelType
+            )
+            _boilerListResult.value = result
+        }
+    }
 }
+

--- a/feature/src/main/java/com/ssafy/feature/boiler/viewmodel/BoilerViewModel.kt
+++ b/feature/src/main/java/com/ssafy/feature/boiler/viewmodel/BoilerViewModel.kt
@@ -1,0 +1,27 @@
+package com.ssafy.feature.boiler.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ssafy.domain.boiler.model.Boiler
+import com.ssafy.domain.boiler.usecase.GetBoilerListUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class BoilerViewModel @Inject constructor(
+    private val getBoilerListUseCase: GetBoilerListUseCase
+) : ViewModel() {
+
+    private val _boilerListResult = MutableLiveData<Result<List<Boiler>>>()
+    val boilerListResult: LiveData<Result<List<Boiler>>> = _boilerListResult
+
+    fun fetchBoilers() {
+        viewModelScope.launch {
+            val result = getBoilerListUseCase()
+            _boilerListResult.value = result
+        }
+    }
+}

--- a/feature/src/main/res/layout/activity_boiler_test.xml
+++ b/feature/src/main/res/layout/activity_boiler_test.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <Button
+        android:id="@+id/button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="보일러 목록 불러오기" />
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="결과가 여기에 표시됩니다"
+        android:paddingTop="16dp" />
+</LinearLayout>

--- a/feature/src/main/res/layout/activity_boiler_test.xml
+++ b/feature/src/main/res/layout/activity_boiler_test.xml
@@ -1,21 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
     android:padding="16dp">
 
-    <Button
-        android:id="@+id/button"
+    <LinearLayout
+        android:orientation="vertical"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="보일러 목록 불러오기" />
+        android:layout_height="wrap_content">
 
-    <TextView
-        android:id="@+id/textView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="결과가 여기에 표시됩니다"
-        android:paddingTop="16dp" />
-</LinearLayout>
+        <!-- 필터 조건 입력 -->
+        <EditText
+            android:id="@+id/etCompanyName"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="회사명" />
+
+        <EditText
+            android:id="@+id/etCertificationType"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="인증종류" />
+
+        <EditText
+            android:id="@+id/etCirculationType"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="순환방식" />
+
+        <EditText
+            android:id="@+id/etFuelType"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="사용연료" />
+
+        <!-- 전체 조회 버튼 -->
+        <Button
+            android:id="@+id/button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="전체 보일러 조회" />
+
+        <!-- 필터 조회 버튼 -->
+        <Button
+            android:id="@+id/filterButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="필터 조건으로 조회" />
+
+        <!-- 결과 출력 -->
+        <TextView
+            android:id="@+id/textView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="결과가 여기에 표시됩니다"
+            android:paddingTop="16dp" />
+    </LinearLayout>
+</ScrollView>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">feature</string>
+<!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>


### PR DESCRIPTION
## 📌 작업 개요
- 보일러 리스트를 기업명, 인증종류, 순환방식, 사용연료로 필터링하여 조회하는 기능 추가

## ✅ 작업 내용
- `BoilerApiService`: 필터 파라미터로 API 수정
- `BoilerRemoteDataSource`: 메소드 파라미터 확장
- `BoilerRepositoryImpl`: 전체 조회/필터 조회 로직 분기 처리
- `GetFilterBoilerListUseCase` 생성 및 DI 등록
- ViewModel 및 UI 테스트 코드 추가

## 🧪 테스트 방법
- 테스트용 FakeDataSource로 필터링 테스트 완료
- 필터 입력 후 '조회' 버튼 클릭 시 정상 필터링 확인

## 🔄 기타 참고 사항
- 추후 서버 연동 시 DI 모듈만 실제 구현체로 교체하면 됨
